### PR TITLE
Fix IOError with livereload + custom config file

### DIFF
--- a/mkdocs/config/base.py
+++ b/mkdocs/config/base.py
@@ -112,7 +112,11 @@ def _open_config_file(config_file):
         else:
             raise exceptions.ConfigurationError(
                 "Config file '{0}' does not exist.".format(config_file))
-
+    else:
+        # reopen config file descriptor when needed
+        if config_file.closed:
+            config_file = open(config_file.name, config_file.mode)
+        config_file.seek(0)
     return config_file
 
 


### PR DESCRIPTION
When using livereload with custom config file, after
first refresh you got IOError. That's because
closed descriptor was reused by load_config()
bot not reinitialized properly, effecting in
stream IO Error (end of file). Fix is to reinitialize
closed file description again every time livereload happens.
